### PR TITLE
improve the logconfig feature and enable http method access

### DIFF
--- a/log_config.go
+++ b/log_config.go
@@ -14,6 +14,8 @@ type InputDetail struct {
 	FilterKeys    []string `json:"filterKey"`
 	FilterRegex   []string `json:"filterRegex"`
 	TopicFormat   string   `json:"topicFormat"`
+	Separator     string   `json:"separator"`
+	AutoExtend    bool     `json:"autoExtend"`
 }
 
 // OutputDetail defines output
@@ -29,6 +31,7 @@ type LogConfig struct {
 	InputDetail  InputDetail  `json:"inputDetail"`
 	OutputType   string       `json:"outputType"`
 	OutputDetail OutputDetail `json:"outputDetail"`
+	LogSample    string       `json:"logSample"`
 
 	CreateTime     uint32
 	LastModifyTime uint32

--- a/log_store.go
+++ b/log_store.go
@@ -377,3 +377,20 @@ func (s *LogStore) GetIndex() (*Index, error) {
 
 	return index, nil
 }
+
+// CheckIndexExist check index exist or not
+func (s *LogStore) CheckIndexExist() (bool, error) {
+	_, err := s.GetIndex()
+	if err != nil {
+		if _, ok := err.(*Error); ok {
+			slsErr := err.(*Error)
+			if slsErr.Code == "IndexConfigNotExist" {
+				return false, nil
+			}
+			return false, slsErr
+		}
+		return false, err
+	}
+
+	return true, nil
+}

--- a/request.go
+++ b/request.go
@@ -52,7 +52,21 @@ func request(project *LogProject, method, uri string, headers map[string]string,
 
 	// Initialize http request
 	reader := bytes.NewReader(body)
-	urlStr := fmt.Sprintf("https://%v.%v%v", project.Name, project.Endpoint, uri)
+
+	// Handle the endpoint
+	httpPrefix := "http://"
+	httpsPrefix := "https://"
+	defaultPrefix := httpsPrefix
+	host := project.Endpoint
+	if len(project.Endpoint) >= len(httpPrefix) && project.Endpoint[0:len(httpPrefix)] == httpPrefix {
+		host = project.Endpoint[len(httpPrefix):]
+		defaultPrefix = httpPrefix
+	} else if len(project.Endpoint) >= len(httpsPrefix) && project.Endpoint[0:len(httpsPrefix)] == httpsPrefix {
+		host = project.Endpoint[len(httpsPrefix):]
+		defaultPrefix = httpsPrefix
+	}
+
+	urlStr := fmt.Sprintf("%s%v.%v%v", defaultPrefix, project.Name, host, uri)
 	req, err := http.NewRequest(method, urlStr, reader)
 	if err != nil {
 		return nil, nil, NewClientError(err.Error())


### PR DESCRIPTION
1. to improve logconfig struct for create logconfig with common_reg_log, json_log and delimiter_log
2. enable endpoint with 'http://'